### PR TITLE
proxy to loopback IP address

### DIFF
--- a/files/Caddyfile
+++ b/files/Caddyfile
@@ -1,3 +1,3 @@
 :80
 
-reverse_proxy :8090
+reverse_proxy 127.0.0.1:8090

--- a/scripts/01_setup_machine.sh
+++ b/scripts/01_setup_machine.sh
@@ -39,7 +39,6 @@ echo "***********************************"
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 sudo ufw allow ssh
-sudo ufw allow 8090
 sudo ufw allow http
 sudo ufw allow https
 sudo ufw --force enable


### PR DESCRIPTION
Exposing port 8090 in the firewall shouldn't be necessary for local app. It allows external clients to call Pocketbase directly via `<public ip address>:8090`. Keep the port blocked from external users, and tell Caddy to proxy to 8090 via the loopback address to avoid Caddy being blocked from speaking with pocketbase.